### PR TITLE
Fix for hidden dot-files in plugins/Networks/lang folder.

### DIFF
--- a/src/main/java/net/quantum625/config/lang/LanguageController.java
+++ b/src/main/java/net/quantum625/config/lang/LanguageController.java
@@ -45,6 +45,11 @@ public class LanguageController {
         File[] files = new File(plugin.getDataFolder(), "lang/").listFiles();
         for (File file : files) {
             try {
+                // Fix for running a server that is stored on a mounted folder and there are one or more .fuse_hidden files
+                // Ie. storage is an NFS share mounted to /mnt/servers
+                // That folder is then bind mounted into a docker container that runs the actual server.
+                if (file.getName().startsWith(".")) continue;
+
                 String key = file.getName().toLowerCase().replaceAll(".yml", "");
                 if (!orderString.contains(key)) {
                     languages.add(new Language(plugin, key));


### PR DESCRIPTION
This fixes a really niche issue that could happen for servers where the files are stored on a network mounted share.

Scenario:
Server files are located on a NAS share
Separate machine with dockerized paper server (ie Crafty Controller)
The mounted share is bind mounted into the docker container