### PR TITLE
Patch 2.1.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "net.quantum625"
-version = "2.1.6"
+version = "2.1.7"
 description = "A performance friendly way to sort your items"
 
 repositories {
@@ -28,7 +28,7 @@ dependencies {
 }
 
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }
 
 bukkit {
@@ -59,6 +59,6 @@ bukkit {
 
 tasks {
     runServer {
-        minecraftVersion("1.20.4")
+        minecraftVersion("1.21")
     }
 }

--- a/src/main/java/net/quantum625/networks/Main.java
+++ b/src/main/java/net/quantum625/networks/Main.java
@@ -8,6 +8,7 @@ import net.quantum625.networks.data.CraftingManager;
 import net.quantum625.networks.inventory.InventoryMenuManager;
 import net.quantum625.networks.utils.DoubleChestUtils;
 import net.quantum625.networks.listener.*;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.spongepowered.configurate.serialize.SerializationException;
 
@@ -25,6 +26,10 @@ public final class Main extends JavaPlugin {
     private CraftingManager crafting;
     private DoubleChestUtils dcu;
     private LanguageController lang;
+
+    public static Plugin getInstance() {
+        return JavaPlugin.getPlugin(Main.class);
+    }
 
     @Override
     public void onEnable() {

--- a/src/main/java/net/quantum625/networks/listener/ItemTransportEventListener.java
+++ b/src/main/java/net/quantum625/networks/listener/ItemTransportEventListener.java
@@ -12,6 +12,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
 
 public class ItemTransportEventListener implements Listener {
     private final NetworkManager net;
@@ -29,16 +30,12 @@ public class ItemTransportEventListener implements Listener {
         if (network == null) return;
         InputContainer container = network.getInputContainerByLocation(location);
         if (container != null) {
-            if (net.sortItem(event.getItem(), location, container.getInventory())) {
-                event.setCancelled(true);
-                for (ItemStack stack : event.getSource().getContents()) {
-                    if (stack == null) continue;
-                    if (stack.isSimilar(event.getItem())) {
-                        stack.setAmount(stack.getAmount() - 1);
-                        break;
-                    }
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    network.sort(container.getPos());
                 }
-            }
+            }.runTask(Main.getInstance());
         }
     }
 }


### PR DESCRIPTION
Fixed that when a hopper points into the vanilla half of an input container double chest, the event handler didn't recognize this part of the double chest as a network component.