### PR TITLE
Patch 2.1.9 - User permissions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "net.quantum625"
-version = "2.1.8"
+version = "2.1.9"
 description = "A performance friendly way to sort your items"
 
 repositories {
@@ -28,7 +28,7 @@ dependencies {
 }
 
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }
 
 bukkit {

--- a/src/main/java/net/quantum625/networks/NetworkManager.java
+++ b/src/main/java/net/quantum625/networks/NetworkManager.java
@@ -117,8 +117,8 @@ public final class NetworkManager {
         return this.networks;
     }
 
-    public ArrayList<Network> listFromOwner(UUID player) {
-        ArrayList<Network> result = new ArrayList<Network>();
+    public Set<Network> listFromOwner(UUID player) {
+        Set<Network> result = new HashSet<>();
         for (Network network : networks) {
             if (network.getOwner().equals(player)) {
                 result.add(network);
@@ -127,8 +127,8 @@ public final class NetworkManager {
         return result;
     }
 
-    public ArrayList<Network> listFromUser(UUID player) {
-        ArrayList<Network> result = new ArrayList<Network>();
+    public Set<Network> listFromUser(UUID player) {
+        Set<Network> result = new HashSet<>();
         for (Network network : networks) {
             if (network.getUsers().contains(player)) {
                 result.add(network);
@@ -144,7 +144,7 @@ public final class NetworkManager {
     public ArrayList<UUID> getNoticedPlayers() {
         ArrayList<UUID> result = new ArrayList<>(noticedPlayers);
         for (Player player : Bukkit.getOnlinePlayers()) {
-            if (listFromUser(player.getUniqueId()).size() > 0) {
+            if (!listFromUser(player.getUniqueId()).isEmpty()) {
                 result.add(player.getUniqueId());
             }
         }

--- a/src/main/java/net/quantum625/networks/commands/NetworksCommand.java
+++ b/src/main/java/net/quantum625/networks/commands/NetworksCommand.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 
@@ -318,12 +319,12 @@ public class NetworksCommand extends CommandHandler {
 
     private void list(CommandContext<CommandSender> context) {
         Player player = (Player) context.getSender();
-        List<Network> list = net.listFromUser(player.getUniqueId());
-        List<Network> owned = net.listFromUser(player.getUniqueId());
+        Set<Network> list = net.listFromUser(player.getUniqueId());
+        Set<Network> owned = net.listFromUser(player.getUniqueId());
 
 
 
-        if (list.size() == 0) {
+        if (list.isEmpty()) {
             lang.message(player, "list.empty");
         }
 
@@ -359,8 +360,8 @@ public class NetworksCommand extends CommandHandler {
 
         Player player = context.get("player");
         CommandSender sender = context.getSender();
-        List<Network> list = net.listFromUser(player.getUniqueId());
-        List<Network> owned = net.listFromOwner(player.getUniqueId());
+        Set<Network> list = net.listFromUser(player.getUniqueId());
+        Set<Network> owned = net.listFromOwner(player.getUniqueId());
 
 
         if (list.size() == 0) {

--- a/src/main/java/net/quantum625/networks/listener/BlockBreakEventListener.java
+++ b/src/main/java/net/quantum625/networks/listener/BlockBreakEventListener.java
@@ -44,7 +44,7 @@ public class BlockBreakEventListener implements Listener {
                     
                     dcu.disconnectChests(component.getPos());
                     
-                    if (net.checkNetworkPermission(event.getPlayer(), network) > 1) {
+                    if (net.checkNetworkPermission(event.getPlayer(), network) > 0) {
                         if (component instanceof InputContainer) {
                             ItemStack inputContainer = crafting.getInputContainer(event.getBlock().getType());
                             Bukkit.getServer().getWorld(component.getPos().getDim()).dropItem(component.getPos().getBukkitLocation(), inputContainer);

--- a/src/main/java/net/quantum625/networks/listener/BlockPlaceEventListener.java
+++ b/src/main/java/net/quantum625/networks/listener/BlockPlaceEventListener.java
@@ -51,7 +51,7 @@ public class BlockPlaceEventListener implements Listener {
 
                 if (item.getItemMeta().getPersistentDataContainer().has(new NamespacedKey("networks", "component_type"), PersistentDataType.STRING)) {
 
-                    if (net.getSelectedNetwork(p) != null) {
+                    if (net.getSelectedNetwork(p) != null && net.checkNetworkPermission(p, network) > 0) {
 
                         String componentType = item.getItemMeta().getPersistentDataContainer().get(new NamespacedKey("networks", "component_type"), PersistentDataType.STRING);
 


### PR DESCRIPTION
Fixed that
- Users couldn't remove network componets
- Users could add network componets after they've been removed from a network until they logged out