### PR TITLE
Update 3.0.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 runPaper.folia.registerTask()
 
 group = "dev.nanoflux"
-version = "3.0.2"
+version = "3.0.3"
 description = "A performance friendly way to sort your items"
 
 repositories {

--- a/src/main/java/dev/nanoflux/config/lang/LanguageController.java
+++ b/src/main/java/dev/nanoflux/config/lang/LanguageController.java
@@ -20,12 +20,15 @@ import java.util.List;
 import java.util.logging.Logger;
 
 public class LanguageController {
+
+    private final JavaPlugin plugin;
     private final Logger logger;
     private final MiniMessage mm;
 
     private final List<Language> languages = new ArrayList<Language>();
 
     public LanguageController(JavaPlugin plugin, String... order) {
+        this.plugin = plugin;
         logger = plugin.getLogger();
         mm = MiniMessage.miniMessage();
 
@@ -82,6 +85,20 @@ public class LanguageController {
      */
     public Component get(String path) throws InvalidNodeException {
         return mm.deserialize(getPreparedString(path));
+    }
+
+    /**
+     * @param path The path of the requested node
+     * @return the given node
+     * @throws InvalidNodeException When you give a non-existent node
+     */
+    public Component getFinal(String path) {
+        try {
+            return mm.deserialize(getPreparedString(path));
+        } catch (InvalidNodeException e) {
+            logger.severe("Invalid language key: " + path);
+            return Component.text(plugin.getName() + "." + path);
+        }
     }
 
 

--- a/src/main/java/dev/nanoflux/networks/Config.java
+++ b/src/main/java/dev/nanoflux/networks/Config.java
@@ -34,6 +34,7 @@ public class Config {
             config.require("lang");
             config.require("range");
             config.require("maxNetworks");
+            config.require("propertyLore");
             config.require("properties.baseRange", "properties.maxComponents", "properties.maxUsers");
             config.require("component.input", "component.sorting", "component.misc");
             config.require("material.component");
@@ -84,6 +85,7 @@ public class Config {
             archiveNetworksOnDelete = config.getFinalBoolean("archiveNetworksOnDelete");
             requestOwnershipTransfers = config.getFinalBoolean("requestOwnershipTransfers");
             complexInventoryChecks = config.getFinalBoolean("performance.complexInventoryChecks");
+            propertyLore = config.getFinalBoolean("propertyLore");
             loadChunks = config.getFinalBoolean("performance.loadChunks");
             commands = config.getFinalList("commands", String.class).toArray(new String[0]);
 
@@ -98,6 +100,7 @@ public class Config {
     public static boolean archiveNetworksOnDelete;
     public static boolean requestOwnershipTransfers;
     public static boolean complexInventoryChecks;
+    public static boolean propertyLore;
     public static boolean loadChunks;
     public static String[] commands;
 

--- a/src/main/java/dev/nanoflux/networks/CraftingManager.java
+++ b/src/main/java/dev/nanoflux/networks/CraftingManager.java
@@ -158,9 +158,9 @@ public class CraftingManager {
     }
 
     private void registerComponent(ComponentType type) {
-        for (Material mat : pluginconfig.componentBlocks(type)) {
-            registerComponentWithMaterial(type, mat);
-        }
+//        for (Material mat : pluginconfig.componentBlocks(type)) {
+//            registerComponentWithMaterial(type, mat);
+//        }
         registerComponentWithMaterial(type, pluginconfig.getComponentUpgradeMaterial());
     }
 
@@ -170,7 +170,7 @@ public class CraftingManager {
         String configPath = "component."+ type.tag + ".block";
         String matkey = mat.name();
 
-        ItemStack stack = type.item(mat);
+        ItemStack stack = type.item();
 
         String registerPath = configPath + "." + matkey;
 

--- a/src/main/java/dev/nanoflux/networks/Main.java
+++ b/src/main/java/dev/nanoflux/networks/Main.java
@@ -116,7 +116,7 @@ public final class Main extends JavaPlugin {
 
         new ComponentListener(this);
         new BlockPlaceListener(this, dcu);
-        new BlockBreakListener(this, crafting, dcu);
+        new BlockBreakListener(this, dcu);
         new WandListener(this, crafting, dcu);
         new PlayerJoinListener(this);
 

--- a/src/main/java/dev/nanoflux/networks/Main.java
+++ b/src/main/java/dev/nanoflux/networks/Main.java
@@ -12,6 +12,9 @@ import dev.nanoflux.networks.event.WandListener;
 import dev.nanoflux.networks.event.PlayerJoinListener;
 import dev.nanoflux.networks.utils.BlockLocation;
 import dev.nanoflux.networks.utils.DoubleChestUtils;
+import io.papermc.paper.threadedregions.scheduler.AsyncScheduler;
+import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
+import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.spongepowered.configurate.serialize.SerializationException;
 
@@ -25,8 +28,13 @@ import java.util.logging.Logger;
 
 public final class Main extends JavaPlugin {
 
-    // Variables
+    public static Main instance;
+
     public static Logger logger;
+
+    public static RegionScheduler regionScheduler;
+    public static GlobalRegionScheduler globalRegionScheduler;
+    public static AsyncScheduler asyncScheduler;
 
     public static Manager manager;
     public static Config config;
@@ -37,6 +45,8 @@ public final class Main extends JavaPlugin {
 
     @Override
     public void onEnable() {
+
+        instance = this;
 
         // Create folders
         try {
@@ -59,6 +69,10 @@ public final class Main extends JavaPlugin {
 
 
         logger = getLogger();
+
+        regionScheduler = getServer().getRegionScheduler();
+        globalRegionScheduler = getServer().getGlobalRegionScheduler();
+        asyncScheduler = getServer().getAsyncScheduler();
 
 
         if (!getDataFolder().exists()) {

--- a/src/main/java/dev/nanoflux/networks/Sorter.java
+++ b/src/main/java/dev/nanoflux/networks/Sorter.java
@@ -38,7 +38,7 @@ public class Sorter {
             if (item == null) continue;
             try {
                 for (Acceptor acceptor : acceptors) {
-                    if (acceptor.ready() && acceptor.pos().getDistance(donator.pos()) <= ranges[donator.range()] + network.range() && Acceptor.spaceFree(acceptor.inventory(), item) && acceptor.accept(item)) {
+                    if (acceptor.ready() && acceptor.pos().getDistance(donator.pos()) <= ranges[Math.min(donator.range(), ranges.length - 1)] + network.range() && Acceptor.spaceFree(acceptor.inventory(), item) && acceptor.accept(item)) {
                         transmit(item, donator, acceptor);
                         break;
                     }
@@ -57,7 +57,7 @@ public class Sorter {
             if (item == null) continue;
             try {
                 for (Supplier supplier : suppliers) {
-                    if (supplier.ready() && supplier.pos().getDistance(requestor.pos()) <= ranges[requestor.range()] + network.range() && supplier.supply().contains(item)) {
+                    if (supplier.ready() && supplier.pos().getDistance(requestor.pos()) <= ranges[Math.min(requestor.range(), ranges.length - 1)] + network.range() && supplier.supply().contains(item)) {
                         transmit(item, supplier, requestor);
                         break;
                     }

--- a/src/main/java/dev/nanoflux/networks/component/ComponentType.java
+++ b/src/main/java/dev/nanoflux/networks/component/ComponentType.java
@@ -6,16 +6,13 @@ import dev.nanoflux.networks.component.component.MiscContainer;
 import dev.nanoflux.networks.component.component.SortingContainer;
 import dev.nanoflux.networks.utils.BlockLocation;
 import net.kyori.adventure.text.Component;
-import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 public class ComponentType {
     public final Class<? extends NetworkComponent> clazz;
@@ -28,7 +25,7 @@ public class ComponentType {
     public final boolean requestor;
 
     public final BiFunction<BlockLocation, PersistentDataContainer, ?extends NetworkComponent> constructor;
-    public final Function<Material, ItemStack> item;
+    public final Map<String, Object> defaultProperties;
 
     public static HashMap<String, ComponentType> tags = new HashMap<>();
     public static HashMap<Class<? extends NetworkComponent>, ComponentType> types = new HashMap<>();
@@ -41,8 +38,8 @@ public class ComponentType {
     public static ComponentType MISC = MiscContainer.register();
 
 
-    public static ComponentType register(Class<? extends NetworkComponent> clazz, String tag, Component name, boolean donator, boolean acceptor, boolean supplier, boolean requestor, BiFunction<BlockLocation, PersistentDataContainer, ?extends NetworkComponent> constructor, Function<Material, ItemStack> item) {
-        ComponentType type = new ComponentType(clazz, tag, name, donator, acceptor, supplier, requestor, constructor, item);
+    public static ComponentType register(Class<? extends NetworkComponent> clazz, String tag, Component name, boolean donator, boolean acceptor, boolean supplier, boolean requestor, BiFunction<BlockLocation, PersistentDataContainer, ?extends NetworkComponent> constructor, Map<String, Object> defaultProperties) {
+        ComponentType type = new ComponentType(clazz, tag, name, donator, acceptor, supplier, requestor, constructor, defaultProperties);
         tags.put(tag, type);
         types.put(clazz, type);
         return type;
@@ -61,10 +58,10 @@ public class ComponentType {
         return types.get(clazz);
     }
 
-    private ComponentType(Class<? extends NetworkComponent> clazz, String tag, Component name, boolean donator, boolean acceptor, boolean supplier, boolean requestor, BiFunction<BlockLocation, PersistentDataContainer, ?extends NetworkComponent> constructor, Function<Material, ItemStack> item) {
+    private ComponentType(Class<? extends NetworkComponent> clazz, String tag, Component name, boolean donator, boolean acceptor, boolean supplier, boolean requestor, BiFunction<BlockLocation, PersistentDataContainer, ?extends NetworkComponent> constructor, Map<String, Object> defaultProperties) {
 
         this.constructor = constructor;
-        this.item = item;
+        this.defaultProperties = defaultProperties;
 
         this.clazz = clazz;
 
@@ -91,8 +88,8 @@ public class ComponentType {
         return constructor.apply(pos, container);
     }
 
-    public ItemStack item(Material mat) {
-        return item.apply(mat);
+    public ItemStack item() {
+        return NetworkComponent.item(this, defaultProperties);
     }
 
 }

--- a/src/main/java/dev/nanoflux/networks/component/NetworkComponent.java
+++ b/src/main/java/dev/nanoflux/networks/component/NetworkComponent.java
@@ -112,9 +112,6 @@ public abstract class NetworkComponent {
             else if (value instanceof Boolean) {
                 container.set(NamespaceUtils.key(key), PersistentDataType.BYTE, (boolean) value ? (byte) 1 : (byte) 0);
             }
-            else if (value instanceof String[]) {
-                container.set(NamespaceUtils.key(key), PersistentDataType.STRING, String.join(",", (String[]) value));
-            }
             else if (value instanceof Integer[]) {
                 container.set(NamespaceUtils.key(key), PersistentDataType.INTEGER_ARRAY, (int[]) value);
             }

--- a/src/main/java/dev/nanoflux/networks/component/NetworkComponent.java
+++ b/src/main/java/dev/nanoflux/networks/component/NetworkComponent.java
@@ -45,6 +45,9 @@ public abstract class NetworkComponent {
     public abstract Map<String, Object> properties();
 
     public abstract ItemStack item(Material material);
+    public ItemStack item() {
+        return item(Main.config.getComponentUpgradeMaterial());
+    }
 
     public @Nullable Inventory inventory() {
 

--- a/src/main/java/dev/nanoflux/networks/component/NetworkComponent.java
+++ b/src/main/java/dev/nanoflux/networks/component/NetworkComponent.java
@@ -5,6 +5,7 @@ import dev.nanoflux.networks.Config;
 import dev.nanoflux.networks.Main;
 import dev.nanoflux.networks.utils.BlockLocation;
 import dev.nanoflux.networks.utils.NamespaceUtils;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -17,6 +18,8 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 public abstract class NetworkComponent {
@@ -44,9 +47,87 @@ public abstract class NetworkComponent {
 
     public abstract Map<String, Object> properties();
 
-    public abstract ItemStack item(Material material);
+    /**
+     * @return The installable item for this component
+     */
     public ItemStack item() {
-        return item(Main.config.getComponentUpgradeMaterial());
+        return item(type(), properties());
+    }
+
+    /**
+     * @return The installable item for this component
+     */
+    public static ItemStack item(ComponentType type, Map<String, Object> properties) {
+        ItemStack stack = new ItemStack(Main.config.getComponentUpgradeMaterial());
+        ItemMeta meta = stack.getItemMeta();
+        try {
+            meta.displayName(Main.lang.getItemName("component." + type.tag()));
+            List<Component> lore = Main.lang.getItemLore("component." + type.tag());
+            if (Config.propertyLore)
+                for (Map.Entry<String, Object> entry : properties.entrySet()) {
+                    lore.add(Main.lang.getFinal("property." + entry.getKey()).append(Component.text(": " + entry.getValue())));
+                }
+            meta.lore(lore);
+        } catch (InvalidNodeException e) {
+            throw new RuntimeException(e);
+        }
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
+        mapToContainer(data, properties);
+        stack.setItemMeta(meta);
+        return stack;
+    }
+
+    /**
+     * Copies all properties from the map to the persistent data container
+     * @param container The persistent data container to edit
+     * @param map The map of properties
+     * @throws IllegalArgumentException Supported data types are String, Integer, Long, Double, Float, Short, Byte, Boolean, Integer[], Long[], Byte[]
+     */
+    private static void mapToContainer(PersistentDataContainer container, Map<String,Object> map) {
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (value instanceof String) {
+                container.set(NamespaceUtils.key(key), PersistentDataType.STRING, (String) value);
+            }
+            else if (value instanceof Integer) {
+                container.set(NamespaceUtils.key(key), PersistentDataType.INTEGER, (int) value);
+            }
+            else if (value instanceof Long) {
+                container.set(NamespaceUtils.key(key), PersistentDataType.LONG, (long) value);
+            }
+            else if (value instanceof Double) {
+                container.set(NamespaceUtils.key(key), PersistentDataType.DOUBLE, (double) value);
+            }
+            else if (value instanceof Float) {
+                container.set(NamespaceUtils.key(key), PersistentDataType.FLOAT, (float) value);
+            }
+            else if (value instanceof Short) {
+                container.set(NamespaceUtils.key(key), PersistentDataType.SHORT, (short) value);
+            }
+            else if (value instanceof Byte) {
+                container.set(NamespaceUtils.key(key), PersistentDataType.BYTE, (byte) value);
+            }
+            else if (value instanceof Boolean) {
+                container.set(NamespaceUtils.key(key), PersistentDataType.BYTE, (boolean) value ? (byte) 1 : (byte) 0);
+            }
+            else if (value instanceof String[]) {
+                container.set(NamespaceUtils.key(key), PersistentDataType.STRING, String.join(",", (String[]) value));
+            }
+            else if (value instanceof Integer[]) {
+                container.set(NamespaceUtils.key(key), PersistentDataType.INTEGER_ARRAY, (int[]) value);
+            }
+            else if (value instanceof Long[]) {
+                container.set(NamespaceUtils.key(key), PersistentDataType.LONG_ARRAY, (long[]) value);
+            }
+            else if (value instanceof Byte[]) {
+                container.set(NamespaceUtils.key(key), PersistentDataType.BYTE_ARRAY, (byte[]) value);
+            }
+            else {
+                throw new IllegalArgumentException("Unsupported value type: " + value.getClass() + " for key: " + key + " and value: " + value + "\nPlease report this to the networks developers / developers of networks addons");
+            }
+        }
     }
 
     public @Nullable Inventory inventory() {

--- a/src/main/java/dev/nanoflux/networks/component/component/InputContainer.java
+++ b/src/main/java/dev/nanoflux/networks/component/component/InputContainer.java
@@ -42,32 +42,6 @@ public class InputContainer extends NetworkComponent implements Donator {
         super(pos);
     }
 
-//    protected static ItemStack newItem(Material material) {
-//        ItemStack stack = new ItemStack(material);
-//        ItemMeta meta = stack.getItemMeta();
-//        try {
-//            meta.displayName(Main.lang.getItemName("component." + type.tag()));
-//            meta.lore(Main.lang.getItemLore("component." + type.tag()));
-//        } catch (InvalidNodeException e) {
-//            throw new RuntimeException(e);
-//        }
-//        PersistentDataContainer data = meta.getPersistentDataContainer();
-//        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
-//        stack.setItemMeta(meta);
-//        return stack;
-//    }
-
-//    @Override
-//    public ItemStack item(Material material) {
-//        ItemStack stack = newItem(material);
-//        ItemMeta meta = stack.getItemMeta();
-//        PersistentDataContainer data = meta.getPersistentDataContainer();
-//        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
-//        data.set(NamespaceUtils.RANGE.key(), PersistentDataType.INTEGER, range);
-//        stack.setItemMeta(meta);
-//        return stack;
-//    }
-
     private static Map<String, Object> defaultProperties = new HashMap<>();
 
     static {

--- a/src/main/java/dev/nanoflux/networks/component/component/InputContainer.java
+++ b/src/main/java/dev/nanoflux/networks/component/component/InputContainer.java
@@ -1,16 +1,12 @@
 package dev.nanoflux.networks.component.component;
 
-import dev.nanoflux.networks.Main;
 import dev.nanoflux.networks.component.ComponentType;
 import dev.nanoflux.networks.component.NetworkComponent;
 import dev.nanoflux.networks.component.module.Donator;
-import dev.nanoflux.config.util.exceptions.InvalidNodeException;
 import dev.nanoflux.networks.utils.BlockLocation;
 import dev.nanoflux.networks.utils.NamespaceUtils;
 import net.kyori.adventure.text.Component;
-import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
@@ -46,30 +42,36 @@ public class InputContainer extends NetworkComponent implements Donator {
         super(pos);
     }
 
-    protected static ItemStack newItem(Material material) {
-        ItemStack stack = new ItemStack(material);
-        ItemMeta meta = stack.getItemMeta();
-        try {
-            meta.displayName(Main.lang.getItemName("component." + type.tag()));
-            meta.lore(Main.lang.getItemLore("component." + type.tag()));
-        } catch (InvalidNodeException e) {
-            throw new RuntimeException(e);
-        }
-        PersistentDataContainer data = meta.getPersistentDataContainer();
-        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
-        stack.setItemMeta(meta);
-        return stack;
-    }
+//    protected static ItemStack newItem(Material material) {
+//        ItemStack stack = new ItemStack(material);
+//        ItemMeta meta = stack.getItemMeta();
+//        try {
+//            meta.displayName(Main.lang.getItemName("component." + type.tag()));
+//            meta.lore(Main.lang.getItemLore("component." + type.tag()));
+//        } catch (InvalidNodeException e) {
+//            throw new RuntimeException(e);
+//        }
+//        PersistentDataContainer data = meta.getPersistentDataContainer();
+//        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
+//        stack.setItemMeta(meta);
+//        return stack;
+//    }
 
-    @Override
-    public ItemStack item(Material material) {
-        ItemStack stack = newItem(material);
-        ItemMeta meta = stack.getItemMeta();
-        PersistentDataContainer data = meta.getPersistentDataContainer();
-        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
-        data.set(NamespaceUtils.RANGE.key(), PersistentDataType.INTEGER, range);
-        stack.setItemMeta(meta);
-        return stack;
+//    @Override
+//    public ItemStack item(Material material) {
+//        ItemStack stack = newItem(material);
+//        ItemMeta meta = stack.getItemMeta();
+//        PersistentDataContainer data = meta.getPersistentDataContainer();
+//        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
+//        data.set(NamespaceUtils.RANGE.key(), PersistentDataType.INTEGER, range);
+//        stack.setItemMeta(meta);
+//        return stack;
+//    }
+
+    private static Map<String, Object> defaultProperties = new HashMap<>();
+
+    static {
+        defaultProperties.put(NamespaceUtils.RANGE.name, 0);
     }
 
     public static ComponentType register() {
@@ -82,7 +84,7 @@ public class InputContainer extends NetworkComponent implements Donator {
                 false, 
                 false,
                 InputContainer::create,
-                InputContainer::newItem
+                defaultProperties
         );
         return type;
     }

--- a/src/main/java/dev/nanoflux/networks/component/component/MiscContainer.java
+++ b/src/main/java/dev/nanoflux/networks/component/component/MiscContainer.java
@@ -1,17 +1,13 @@
 package dev.nanoflux.networks.component.component;
 
-import dev.nanoflux.networks.Main;
 import dev.nanoflux.networks.component.ComponentType;
 import dev.nanoflux.networks.component.NetworkComponent;
-import dev.nanoflux.config.util.exceptions.InvalidNodeException;
 import dev.nanoflux.networks.component.module.Acceptor;
 import dev.nanoflux.networks.component.module.Supplier;
 import dev.nanoflux.networks.utils.BlockLocation;
 import dev.nanoflux.networks.utils.NamespaceUtils;
 import net.kyori.adventure.text.Component;
-import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
@@ -51,31 +47,38 @@ public class MiscContainer extends NetworkComponent implements Acceptor, Supplie
         super(pos);
     }
 
-    protected static ItemStack newItem(Material material) {
-        ItemStack stack = new ItemStack(material);
-        ItemMeta meta = stack.getItemMeta();
-        try {
-            meta.displayName(Main.lang.getItemName("component." + type.tag()));
-            meta.lore(Main.lang.getItemLore("component." + type.tag()));
-        } catch (InvalidNodeException e) {
-            throw new RuntimeException(e);
-        }
-        PersistentDataContainer data = meta.getPersistentDataContainer();
-        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
-        stack.setItemMeta(meta);
-        return stack;
-    }
+//    protected static ItemStack newItem(Material material) {
+//        ItemStack stack = new ItemStack(material);
+//        ItemMeta meta = stack.getItemMeta();
+//        try {
+//            meta.displayName(Main.lang.getItemName("component." + type.tag()));
+//            meta.lore(Main.lang.getItemLore("component." + type.tag()));
+//        } catch (InvalidNodeException e) {
+//            throw new RuntimeException(e);
+//        }
+//        PersistentDataContainer data = meta.getPersistentDataContainer();
+//        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
+//        stack.setItemMeta(meta);
+//        return stack;
+//    }
+//
+//    @Override
+//    public ItemStack item(Material material) {
+//        ItemStack stack = newItem(material);
+//        ItemMeta meta = stack.getItemMeta();
+//        PersistentDataContainer data = meta.getPersistentDataContainer();
+//        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
+//        data.set(NamespaceUtils.ACCEPTOR_PRIORITY.key(), PersistentDataType.INTEGER, acceptorPriority);
+//        data.set(NamespaceUtils.SUPPLIER_PRIORITY.key(), PersistentDataType.INTEGER, supplierPriority);
+//        stack.setItemMeta(meta);
+//        return stack;
+//    }
 
-    @Override
-    public ItemStack item(Material material) {
-        ItemStack stack = newItem(material);
-        ItemMeta meta = stack.getItemMeta();
-        PersistentDataContainer data = meta.getPersistentDataContainer();
-        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
-        data.set(NamespaceUtils.ACCEPTOR_PRIORITY.key(), PersistentDataType.INTEGER, acceptorPriority);
-        data.set(NamespaceUtils.SUPPLIER_PRIORITY.key(), PersistentDataType.INTEGER, supplierPriority);
-        stack.setItemMeta(meta);
-        return stack;
+    private static Map<String, Object> defaultProperties = new HashMap<>();
+
+    static {
+        defaultProperties.put(NamespaceUtils.ACCEPTOR_PRIORITY.name, -20);
+        defaultProperties.put(NamespaceUtils.SUPPLIER_PRIORITY.name, 5);
     }
 
     public static ComponentType register() {
@@ -88,7 +91,7 @@ public class MiscContainer extends NetworkComponent implements Acceptor, Supplie
                 true,
                 false,
                 MiscContainer::create,
-                MiscContainer::newItem
+                defaultProperties
         );
         return type;
     }
@@ -126,8 +129,8 @@ public class MiscContainer extends NetworkComponent implements Acceptor, Supplie
     @Override
     public Map<String, Object> properties() {
         return new HashMap<>() {{
-            put("acceptorPriority", acceptorPriority);
-            put("supplierPriority", supplierPriority);
+            put(NamespaceUtils.ACCEPTOR_PRIORITY.name, acceptorPriority);
+            put(NamespaceUtils.SUPPLIER_PRIORITY.name, supplierPriority);
         }};
     }
 

--- a/src/main/java/dev/nanoflux/networks/component/component/MiscContainer.java
+++ b/src/main/java/dev/nanoflux/networks/component/component/MiscContainer.java
@@ -47,33 +47,6 @@ public class MiscContainer extends NetworkComponent implements Acceptor, Supplie
         super(pos);
     }
 
-//    protected static ItemStack newItem(Material material) {
-//        ItemStack stack = new ItemStack(material);
-//        ItemMeta meta = stack.getItemMeta();
-//        try {
-//            meta.displayName(Main.lang.getItemName("component." + type.tag()));
-//            meta.lore(Main.lang.getItemLore("component." + type.tag()));
-//        } catch (InvalidNodeException e) {
-//            throw new RuntimeException(e);
-//        }
-//        PersistentDataContainer data = meta.getPersistentDataContainer();
-//        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
-//        stack.setItemMeta(meta);
-//        return stack;
-//    }
-//
-//    @Override
-//    public ItemStack item(Material material) {
-//        ItemStack stack = newItem(material);
-//        ItemMeta meta = stack.getItemMeta();
-//        PersistentDataContainer data = meta.getPersistentDataContainer();
-//        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
-//        data.set(NamespaceUtils.ACCEPTOR_PRIORITY.key(), PersistentDataType.INTEGER, acceptorPriority);
-//        data.set(NamespaceUtils.SUPPLIER_PRIORITY.key(), PersistentDataType.INTEGER, supplierPriority);
-//        stack.setItemMeta(meta);
-//        return stack;
-//    }
-
     private static Map<String, Object> defaultProperties = new HashMap<>();
 
     static {

--- a/src/main/java/dev/nanoflux/networks/component/component/SortingContainer.java
+++ b/src/main/java/dev/nanoflux/networks/component/component/SortingContainer.java
@@ -1,18 +1,14 @@
 package dev.nanoflux.networks.component.component;
 
-import dev.nanoflux.networks.Main;
 import dev.nanoflux.networks.component.ComponentType;
 import dev.nanoflux.networks.component.NetworkComponent;
 import dev.nanoflux.networks.component.module.Acceptor;
 import dev.nanoflux.networks.component.module.Supplier;
-import dev.nanoflux.config.util.exceptions.InvalidNodeException;
 import dev.nanoflux.networks.utils.BlockLocation;
 import dev.nanoflux.networks.utils.NamespaceUtils;
 import net.kyori.adventure.text.Component;
 import org.apache.commons.lang3.ArrayUtils;
-import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
@@ -55,33 +51,41 @@ public class SortingContainer extends NetworkComponent implements Acceptor, Supp
         this.supplierPriority = supplierPriority;
     }
 
-    private static ItemStack newItem(Material material) {
-        ItemStack stack = new ItemStack(material);
-        ItemMeta meta = stack.getItemMeta();
-        try {
-            meta.displayName(Main.lang.getItemName("component." + type.tag()));
-            meta.lore(Main.lang.getItemLore("component." + type.tag()));
-            meta.getPersistentDataContainer().set(NamespaceUtils.FILTERS.key(), PersistentDataType.STRING, ",");
-        } catch (InvalidNodeException e) {
-            throw new RuntimeException(e);
-        }
-        PersistentDataContainer data = meta.getPersistentDataContainer();
-        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
-        stack.setItemMeta(meta);
-        return stack;
-    }
+//    private static ItemStack newItem(Material material) {
+//        ItemStack stack = new ItemStack(material);
+//        ItemMeta meta = stack.getItemMeta();
+//        try {
+//            meta.displayName(Main.lang.getItemName("component." + type.tag()));
+//            meta.lore(Main.lang.getItemLore("component." + type.tag()));
+//            meta.getPersistentDataContainer().set(NamespaceUtils.FILTERS.key(), PersistentDataType.STRING, ",");
+//        } catch (InvalidNodeException e) {
+//            throw new RuntimeException(e);
+//        }
+//        PersistentDataContainer data = meta.getPersistentDataContainer();
+//        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
+//        stack.setItemMeta(meta);
+//        return stack;
+//    }
+//
+//    @Override
+//    public ItemStack item(Material material) {
+//        ItemStack stack = newItem(material);
+//        ItemMeta meta = stack.getItemMeta();
+//        PersistentDataContainer data = meta.getPersistentDataContainer();
+//        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
+//        data.set(NamespaceUtils.FILTERS.key(), PersistentDataType.STRING, String.join(",", filters));
+//        data.set(NamespaceUtils.ACCEPTOR_PRIORITY.key(), PersistentDataType.INTEGER, acceptorPriority);
+//        data.set(NamespaceUtils.SUPPLIER_PRIORITY.key(), PersistentDataType.INTEGER, supplierPriority);
+//        stack.setItemMeta(meta);
+//        return stack;
+//    }
 
-    @Override
-    public ItemStack item(Material material) {
-        ItemStack stack = newItem(material);
-        ItemMeta meta = stack.getItemMeta();
-        PersistentDataContainer data = meta.getPersistentDataContainer();
-        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
-        data.set(NamespaceUtils.FILTERS.key(), PersistentDataType.STRING, String.join(",", filters));
-        data.set(NamespaceUtils.ACCEPTOR_PRIORITY.key(), PersistentDataType.INTEGER, acceptorPriority);
-        data.set(NamespaceUtils.SUPPLIER_PRIORITY.key(), PersistentDataType.INTEGER, supplierPriority);
-        stack.setItemMeta(meta);
-        return stack;
+    private static Map<String, Object> defaultProperties = new HashMap<>();
+
+    static {
+        defaultProperties.put(NamespaceUtils.FILTERS.name, "");
+        defaultProperties.put(NamespaceUtils.ACCEPTOR_PRIORITY.name, 10);
+        defaultProperties.put(NamespaceUtils.SUPPLIER_PRIORITY.name, 0);
     }
 
     public static ComponentType register() {
@@ -94,7 +98,7 @@ public class SortingContainer extends NetworkComponent implements Acceptor, Supp
                 true,
                 false,
                 SortingContainer::create,
-                SortingContainer::newItem
+                defaultProperties
         );
         return type;
     }
@@ -136,9 +140,9 @@ public class SortingContainer extends NetworkComponent implements Acceptor, Supp
     @Override
     public Map<String, Object> properties() {
         return new HashMap<>() {{
-            put("acceptorPriority", acceptorPriority);
-            put("supplierPriority", supplierPriority);
-            put("filters", filters);
+            put(NamespaceUtils.ACCEPTOR_PRIORITY.name, acceptorPriority);
+            put(NamespaceUtils.SUPPLIER_PRIORITY.name, supplierPriority);
+            put(NamespaceUtils.FILTERS.name, filters);
         }};
     }
 

--- a/src/main/java/dev/nanoflux/networks/component/component/SortingContainer.java
+++ b/src/main/java/dev/nanoflux/networks/component/component/SortingContainer.java
@@ -51,35 +51,6 @@ public class SortingContainer extends NetworkComponent implements Acceptor, Supp
         this.supplierPriority = supplierPriority;
     }
 
-//    private static ItemStack newItem(Material material) {
-//        ItemStack stack = new ItemStack(material);
-//        ItemMeta meta = stack.getItemMeta();
-//        try {
-//            meta.displayName(Main.lang.getItemName("component." + type.tag()));
-//            meta.lore(Main.lang.getItemLore("component." + type.tag()));
-//            meta.getPersistentDataContainer().set(NamespaceUtils.FILTERS.key(), PersistentDataType.STRING, ",");
-//        } catch (InvalidNodeException e) {
-//            throw new RuntimeException(e);
-//        }
-//        PersistentDataContainer data = meta.getPersistentDataContainer();
-//        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
-//        stack.setItemMeta(meta);
-//        return stack;
-//    }
-//
-//    @Override
-//    public ItemStack item(Material material) {
-//        ItemStack stack = newItem(material);
-//        ItemMeta meta = stack.getItemMeta();
-//        PersistentDataContainer data = meta.getPersistentDataContainer();
-//        data.set(NamespaceUtils.COMPONENT.key(), PersistentDataType.STRING, type.tag());
-//        data.set(NamespaceUtils.FILTERS.key(), PersistentDataType.STRING, String.join(",", filters));
-//        data.set(NamespaceUtils.ACCEPTOR_PRIORITY.key(), PersistentDataType.INTEGER, acceptorPriority);
-//        data.set(NamespaceUtils.SUPPLIER_PRIORITY.key(), PersistentDataType.INTEGER, supplierPriority);
-//        stack.setItemMeta(meta);
-//        return stack;
-//    }
-
     private static Map<String, Object> defaultProperties = new HashMap<>();
 
     static {
@@ -142,7 +113,7 @@ public class SortingContainer extends NetworkComponent implements Acceptor, Supp
         return new HashMap<>() {{
             put(NamespaceUtils.ACCEPTOR_PRIORITY.name, acceptorPriority);
             put(NamespaceUtils.SUPPLIER_PRIORITY.name, supplierPriority);
-            put(NamespaceUtils.FILTERS.name, filters);
+            put(NamespaceUtils.FILTERS.name, String.join(",", filters));
         }};
     }
 

--- a/src/main/java/dev/nanoflux/networks/event/ComponentListener.java
+++ b/src/main/java/dev/nanoflux/networks/event/ComponentListener.java
@@ -8,6 +8,7 @@ import dev.nanoflux.networks.component.NetworkComponent;
 import dev.nanoflux.networks.component.module.Donator;
 import dev.nanoflux.networks.component.module.Requestor;
 import dev.nanoflux.networks.utils.BlockLocation;
+import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryCloseEvent;
@@ -49,12 +50,25 @@ public class ComponentListener implements Listener {
 
     @EventHandler
     public void onItemTransmit(InventoryMoveItemEvent event) {
-        check(event.getDestination().getLocation());
+        Location location = event.getDestination().getLocation();
+        if (location == null) return;
+        Main.regionScheduler.execute(
+                Main.instance,
+                location,
+                () -> check(location)
+        );
+
     }
 
     @EventHandler
     public void onItemPickup(InventoryPickupItemEvent event) {
-        check(event.getInventory().getLocation());
+        Location location = event.getInventory().getLocation();
+        if (location == null) return;
+        Main.regionScheduler.execute(
+                Main.instance,
+                location,
+                () -> check(location)
+        );
     }
 
 }

--- a/src/main/java/dev/nanoflux/networks/utils/NamespaceUtils.java
+++ b/src/main/java/dev/nanoflux/networks/utils/NamespaceUtils.java
@@ -34,4 +34,8 @@ public enum NamespaceUtils {
     public NamespacedKey key() {
         return new NamespacedKey(main, this.name);
     }
+
+    public static NamespacedKey key(String name) {
+        return new NamespacedKey(main, name);
+    }
 }

--- a/src/main/resources/general.conf
+++ b/src/main/resources/general.conf
@@ -53,13 +53,14 @@ properties {
 blastProofComponents = true
 
 
+# Add component properties to the item lore of the component
+propertyLore = true
 
 
 # Notices players, that open full chests to this plugin.
 # This message will only be sent once and just to players, that do not have a network.
 # You can configure the message in the language file.
 notice = true
-
 
 
 # Show Networks text on launch

--- a/src/main/resources/lang/de.yml
+++ b/src/main/resources/lang/de.yml
@@ -102,6 +102,10 @@ info.components.input: "Einfüllkisten: "
 info.components.sorting: "Sortierkisten: "
 info.components.misc: "Restekisten: "
 
+property.range: "<reset><green>Reichweite</green>"
+property.acceptor_priority: "<reset><green>Annahme-Priorität</green>"
+property.supplier_priority: "<reset><green>Abgabe-Priorität</green>"
+property.filters: "<reset><green>Filter</green>"
 
 component.input.add: <prefix>Einfüllkiste bei <1> wurde hinzugefügt zum Netzwerk <2>!
 component.sorting.add: <prefix>Sortierkiste bei <1> wurde hinzugefügt zum Netzwerk <2>!
@@ -184,8 +188,6 @@ item.lore.component.input:
   - "<reset><blue>Sortiert eingelegte Items in Sortier- und Restekisten ein"
 item.lore.component.sorting:
   - "<reset><blue>Akzeptiert nur Items, die dem Filter der Kiste entsprechen"
-  - ""
-  - "<reset>Filter Items:"
 item.lore.component.misc:
   - "<reset><blue>Alle übrigen items gehen in diese Kisten"
 
@@ -195,8 +197,6 @@ item.lore.component.input.upgrade:
 item.lore.component.sorting.upgrade:
   - "<reset><blue>Auf eine Kiste klicken um das Upgrade zu installieren"
   - "<reset><blue>Akzeptiert nur Items, die dem Filter der Kiste entsprechen"
-  - ""
-  - "<reset>Filter Items:"
 item.lore.component.misc.upgrade:
   - "<reset><blue>Auf eine Kiste klicken um das Upgrade zu installieren"
   - "<reset><blue>Alle übrigen items gehen in diese Kisten"

--- a/src/main/resources/lang/en.yml
+++ b/src/main/resources/lang/en.yml
@@ -117,7 +117,7 @@ component.remove: <prefix><red>Removed component at <1>
 component.exploded: <prefix><dark_red>NetworkComponent at <white><1><dark_red> from network <white><2><dark_red> was blown up!
 component.invalid_block: <prefix><red>Blocks of type </red><1><red> are not allowed to be network components!</red>
 component.nocomponent: <prefix><yellow>This block is not a network component!
-component.priority: <prefix>NetworkComponent priority set to <1>
+component.priority: <prefix>Priority set to <1>
 
 location.occupied: <prefix><red>There is already a component at this location!
 

--- a/src/main/resources/lang/en.yml
+++ b/src/main/resources/lang/en.yml
@@ -103,6 +103,10 @@ info.components.input: "Input Containers: "
 info.components.sorting: "Sorting Containers: "
 info.components.misc: "Miscellaneous Containers: "
 
+property.range: "<reset><green>Range</green>"
+property.acceptor_priority: "<reset><green>Acceptor Priority</green>"
+property.supplier_priority: "<reset><green>Supplier Priority</green>"
+property.filters: "<reset><green>Filters</green>"
 
 component.input.add: <prefix>Input container at <1> successfully added to <2>!
 component.sorting.add: <prefix>Sorting container at <1> successfully added to <2>!
@@ -186,8 +190,6 @@ item.lore.component.input:
   - "<reset><blue>Sorts items into sorting containers and misc containers"
 item.lore.component.sorting:
   - "<reset><blue>Only accepts items that match the filter of this container"
-  - ""
-  - "<reset>Filter Items:"
 item.lore.component.misc:
   - "<reset><blue>All remaining items will go into these"
 
@@ -197,8 +199,6 @@ item.lore.component.input.upgrade:
 item.lore.component.sorting.upgrade:
   - "<reset><blue>Right click on a chest to make it a sorting container"
   - "<reset><blue>Only accepts items that match the filter of this container"
-  - ""
-  - "<reset>Filter Items:"
 item.lore.component.misc.upgrade:
   - "<reset><blue>Right click on a chest to make it a misc container"
   - "<reset><blue>All remaining items will go into these"


### PR DESCRIPTION
- No more items hanging in input containers

- Breaking components will drop a component upgrade instead of a component block
(This is to prohibit incompatability with other plugins)

- Dropped components now actually show component properties in their lore
(Opt-out config)

- Component properties are more generalized, so development of new components / addons for Networks is alot easier

- No more error when a donator's range is too high